### PR TITLE
docs：添加默认路径配置地址声名，修改配置文件路径为相对路径

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ cd cilikube
 # (Optional) Update Go dependencies
 go mod tidy
 # Run the back-end service (listens on port 8080 by default)
+# Configuration files are modified in config/config.yaml
 go run cmd/server/main.go
 ```
 
@@ -398,6 +399,7 @@ cd cilikube
 # (可选) 更新 Go 依赖
 go mod tidy
 # 运行后端服务 (默认监听 8080 端口)
+# 配置文件在 config/config.yaml 中修改
 go run cmd/server/main.go
 ```
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -57,7 +57,7 @@ func loadConfig() (*configs.Config, error) {
 
 	// 如果环境变量也未指定，则使用默认路径
 	if configPath == "" {
-		configPath = "configs/config.yaml"
+		configPath = "../../configs/config.yaml"
 	}
 
 	// 调用 configs.Load 方法加载配置


### PR DESCRIPTION
根据 md 文件中直接执行 “cd cmd/server && go run main.go” 时，可能会碰到提示找不到配置文件的问题。这是由于代码里默认的配置文件采用的是绝对路径，在当前环境下直接运行就会出错。

因此把配置文件路径修改成相对路径，另外在 md 文件中添加关于默认路径配置地址的声明，清晰地告诉用户配置文件的位置以及如何进行自定义修改。