### PR TITLE
fix：Fix configuration path derivation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ cd cilikube
 # (Optional) Update Go dependencies
 go mod tidy
 # Run the back-end service (listens on port 8080 by default)
-# Configuration files are modified in config/config.yaml
+# Configuration files are modified in configs/config.yaml
 go run cmd/server/main.go
 ```
 
@@ -406,7 +406,7 @@ cd cmd/server
 # go mod tidy
 
 # 运行后端服务 (默认监听 8080 端口)
-# 配置文件在 config/config.yaml 中修改
+# 配置文件在 configs/config.yaml 中修改
 go run main.go
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -133,6 +133,7 @@ cd cmd/server
 # go mod tidy
 
 # 运行后端服务 (默认监听 8080 端口)
+# 配置文件在 configs/config.yaml 中修改
 go run main.go
 ```
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -57,6 +57,16 @@ func loadConfig() (*configs.Config, error) {
 
 	// 如果环境变量也未指定，则使用默认路径
 	if configPath == "" {
+		//获取工作目录
+		if wd, err := os.Getwd(); err == nil {
+			// 当工作路径为项目根路径时，使用绝对路径
+			configPath = wd + "/configs/config.yaml"
+			if _, err := os.Stat(configPath); err == nil {
+				log.Printf("使用默认配置文件路径: %s\n", configPath)
+				return configs.Load(configPath)
+			}
+		}
+		// 当工作路径为当前路径时，使用相对路径
 		configPath = "../../configs/config.yaml"
 	}
 


### PR DESCRIPTION
fix：修复配置路径推导错误

由于命令行执行 go run main.go 和 在GoLand 中点击运行(Shift +F10)或调试(Shift +F9)时程序的工作路径不同，导致配置文件路径解析不一致。

为避免每次手动修改工作目录或配置路径，可以在程序中动态调整配置文件路径